### PR TITLE
Added "-DGBL_EIGEN_SUPPORT_ROOT" to allow  GBLInterface.cc still use ROOT from GBL.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ ENDIF(DOXYGEN_FOUND)
 
 IF( GBL_FOUND )
         ADD_DEFINITIONS( "-DUSE_GBL" )
+        ADD_DEFINITIONS( "-DGBL_EIGEN_SUPPORT_ROOT" )
 ELSE()
     MESSAGE( STATUS "GBL not found, track fitting with GBL will not be available." )
 ENDIF()


### PR DESCRIPTION

BEGINRELEASENOTES
- Added "-DGBL_EIGEN_SUPPORT_ROOT" to allow  GBLInterface.cc still use ROOT from GBL.

ENDRELEASENOTES