### PR TITLE
Instead of using GENERATE_PACKAGE_CONFIG_FILES call configure_file an…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,6 @@ install(TARGETS ${PROJECT_NAME}
   )
 
 # generate and install following configuration files
-#GENERATE_PACKAGE_CONFIGURATION_FILES( aidaTTConfig.cmake aidaTTConfigVersion.cmake )
-GENERATE_PACKAGE_CONFIGURATION_FILES( aidaTTConfig.cmake )
+CONFIGURE_FILE( ${PROJECT_SOURCE_DIR}/cmake/aidaTTConfig.cmake.in aidaTTConfig.cmake @ONLY )
+INSTALL( FILES ${PROJECT_BINARY_DIR}/aidaTTConfig.cmake DESTINATION . )
 


### PR DESCRIPTION
…d install directly

GENERATE_PACKAGE_CONFIG_FILES no longer available in DD4hep



BEGINRELEASENOTES
- CMake: Instead of using GENERATE_PACKAGE_CONFIG_FILES call configure_file and install directly. Macro was used from DD4hep before (and is no longer available there).

ENDRELEASENOTES