### PR TITLE
Fix dd4hep

### DIFF
--- a/core/include/IGeometry.hh
+++ b/core/include/IGeometry.hh
@@ -8,18 +8,17 @@
 //
 // Use the Surfaces and material classes (interfaces) from DD4hep 
 //
-#include "DDSurfaces/ISurface.h"
-#include "DDSurfaces/IMaterial.h"
+#include "DDRec/ISurface.h"
+#include "DDRec/IMaterial.h"
 
 namespace aidaTT
 {
-  using DDSurfaces::ISurface ;
-  using DDSurfaces::ICylinder ;
-  using DDSurfaces::ICone ;
-  using DDSurfaces::IMaterial ;
-  using DDSurfaces::Vector2D ;
-  using DDSurfaces::Vector3D ;
-  using namespace DDSurfaces ;
+  using dd4hep::rec::ISurface ;
+  using dd4hep::rec::ICylinder ;
+  using dd4hep::rec::ICone ;
+  using dd4hep::rec::IMaterial ;
+  using dd4hep::rec::Vector2D ;
+  using dd4hep::rec::Vector3D ;
 
 }
 #else

--- a/core/include/Vector5.hh
+++ b/core/include/Vector5.hh
@@ -60,8 +60,7 @@ namespace aidaTT
 
     // addition w/ copy
     Vector5 operator+(const Vector5& o) const{
-      Vector5 newVec( *this ) ;
-      return  newVec + o ;
+      return Vector5( _v + o._v ) ;
     } 
 
 

--- a/examples/gbl_example/gbl_example.cpp
+++ b/examples/gbl_example/gbl_example.cpp
@@ -23,7 +23,7 @@
 
 // DD4hep
 #include "DD4hepGeometry.hh"
-#include "DD4hep/LCDD.h"
+#include "DD4hep/Detector.h"
 #include "DD4hep/DD4hepUnits.h"
 #include "DDRec/SurfaceHelper.h"
 
@@ -52,10 +52,10 @@ int main(int argc, char** argv)
     std::string inFile =  argv[1] ;
 
     /// preamble: load the geo info, get all surfaces => entry point for intersection calculation
-    DD4hep::Geometry::LCDD& lcdd = DD4hep::Geometry::LCDD::getInstance();
+    dd4hep::Detector& theDet = dd4hep::LCDD::getInstance();
     lcdd.fromCompact(inFile);
 
-    DD4hep::Geometry::DetElement world = lcdd.world() ;
+    dd4hep::DetElement world = theDet.world() ;
 
     aidaTT::DD4hepGeometry geom(world);
 

--- a/examples/geometry_test/geometry_test.cpp
+++ b/examples/geometry_test/geometry_test.cpp
@@ -6,7 +6,7 @@
 #include "IGeometry.hh"
 
 // DD4hep
-#include "DD4hep/LCDD.h"
+#include "DD4hep/Detector.h"
 #include "DDRec/SurfaceHelper.h"
 
 int main(int argc, char** argv)
@@ -20,17 +20,17 @@ int main(int argc, char** argv)
 
     std::string inFile =  argv[1] ;
 
-    DD4hep::Geometry::LCDD& lcdd = DD4hep::Geometry::LCDD::getInstance();
-    lcdd.fromCompact(inFile);
+    dd4hep::Detector& theDet = dd4hep::Detector::getInstance();
+    theDet.fromCompact(inFile);
 
-    DD4hep::Geometry::DetElement world = lcdd.world() ;
+    dd4hep::DetElement world = theDet.world() ;
 
     // create a list of all surfaces in the detector:
-    DD4hep::DDRec::SurfaceHelper surfMan(world) ;
+    dd4hep::rec::SurfaceHelper surfMan(world) ;
 
-    const DD4hep::DDRec::SurfaceList& sL = surfMan.surfaceList() ;
+    const dd4hep::rec::SurfaceList& sL = surfMan.surfaceList() ;
 
-    for(DD4hep::DDRec::SurfaceList::const_iterator it = sL.begin() ; it != sL.end() ; ++it)
+    for(dd4hep::rec::SurfaceList::const_iterator it = sL.begin() ; it != sL.end() ; ++it)
         {
 
             aidaTT::ISurface* surf =  *it ;

--- a/examples/material_effects/check_materials.cpp
+++ b/examples/material_effects/check_materials.cpp
@@ -86,8 +86,8 @@ int main(int argc, char** argv) {
 						     s, xx, 0 , true ) ; 
 
     //----------------- get X0 --------------------------------------------
-    const DDSurfaces::IMaterial& material_inn = surf->innerMaterial();
-    const DDSurfaces::IMaterial& material_out = surf->outerMaterial();
+    const dd4hep::rec::IMaterial& material_inn = surf->innerMaterial();
+    const dd4hep::rec::IMaterial& material_out = surf->outerMaterial();
     
     const double r_i = surf->innerThickness();
     const double r_o = surf->outerThickness();

--- a/examples/material_effects/material_ntuples.cpp
+++ b/examples/material_effects/material_ntuples.cpp
@@ -123,8 +123,8 @@ int main(int argc, char** argv) {
 							 s, xx, 0 , true ) ; 
 	
 	//----------------- get X0 --------------------------------------------
-	const DDSurfaces::IMaterial& material_inn = surf->innerMaterial();
-	const DDSurfaces::IMaterial& material_out = surf->outerMaterial();
+	const dd4hep::rec::IMaterial& material_inn = surf->innerMaterial();
+	const dd4hep::rec::IMaterial& material_out = surf->outerMaterial();
 	
 	const double r_i = surf->innerThickness();
 	const double r_o = surf->outerThickness();

--- a/examples/material_effects/material_ntuples.cpp
+++ b/examples/material_effects/material_ntuples.cpp
@@ -7,7 +7,7 @@
 #include "IGeometry.hh"
 #include "trackParameters.hh"
 
-#include "DD4hep/LCDD.h"
+#include "DD4hep/Detector.h"
 #include "DDRec/MaterialManager.h"
 
 // ROOT
@@ -21,8 +21,8 @@
 using namespace std ;
 //using namespace aidaTT ;
 
-using namespace DD4hep ;
-using namespace DD4hep::DDRec ;
+using namespace dd4hep ;
+using namespace dd4hep::rec ;
 
 
 

--- a/geometry/src/DD4hepGeometry.cc
+++ b/geometry/src/DD4hepGeometry.cc
@@ -18,7 +18,7 @@ namespace aidaTT
 
     if( surf->type().isZCylinder() ){
 
-      return dynamic_cast<const DDSurfaces::ICylinder*>(surf)->radius() ;
+      return dynamic_cast<const dd4hep::rec::ICylinder*>(surf)->radius() ;
 
     } else if( surf->type().isZPlane() ){  
 
@@ -30,7 +30,7 @@ namespace aidaTT
 
     } else    if( surf->type().isZCone() ){
 
-      const ICone* c = dynamic_cast<const DDSurfaces::ICone*>(surf) ;
+      const ICone* c = dynamic_cast<const dd4hep::rec::ICone*>(surf) ;
 
       return  std::max( c->radius0() ,  c->radius1() ) ;
 

--- a/util/src/materialUtils.cc
+++ b/util/src/materialUtils.cc
@@ -38,8 +38,8 @@ namespace aidaTT{
 
   double computeQMS( const ISurface* surf, const Vector2D& crossingPoint, const Vector3D& momentum , double mass ) {
     
-    const DDSurfaces::IMaterial& material_inn = surf->innerMaterial();
-    const DDSurfaces::IMaterial& material_out = surf->outerMaterial();
+    const dd4hep::rec::IMaterial& material_inn = surf->innerMaterial();
+    const dd4hep::rec::IMaterial& material_out = surf->outerMaterial();
     
     const double r_i = surf->innerThickness();
     const double r_o = surf->outerThickness();
@@ -145,8 +145,8 @@ namespace aidaTT{
 			    const Vector3D& momentum, double& energy, double& beta,
 			    double mass ){
     
-    const DDSurfaces::IMaterial& material_i = surf->innerMaterial(); // crossingPoint
-    const DDSurfaces::IMaterial& material_o = surf->outerMaterial(); // crossingPoint
+    const dd4hep::rec::IMaterial& material_i = surf->innerMaterial(); // crossingPoint
+    const dd4hep::rec::IMaterial& material_o = surf->outerMaterial(); // crossingPoint
     
     double path_i = surf->innerThickness();
     double path_o = surf->outerThickness();


### PR DESCRIPTION

BEGINRELEASENOTES
-  adapt examples to recent namespace change in DD4hep
- replace DDSurfaces with dd4hep::rec
- fix -Winfinite-recursion in Vector5 (operator+)

ENDRELEASENOTES