### PR TITLE
 Update trajectory::addMeasurement from void to bool for adding successfully.

### DIFF
--- a/core/include/AidaTT.hh
+++ b/core/include/AidaTT.hh
@@ -31,7 +31,7 @@
  * where the chosen implementations of the abstract classes are also passed as arguments.
  *
  * Measurements are then added by
- *  void trajectory::addMeasurement(const Vector3D& position, const std::vector<double>& resolution, const ISurface& surface, void* id),
+ *  bool trajectory::addMeasurement(const Vector3D& position, const std::vector<double>& resolution, const ISurface& surface, void* id),
  * other points or elements like scattering material or points of interest (nominal starting point, calorimeter face,...) are added with either
  *    void trajectory::addElement(const Vector3D& position, void* id);
  *    void trajectory::addElement(const Vector3D& position, const ISurface& surface, void* id);

--- a/core/include/trajectory.hh
+++ b/core/include/trajectory.hh
@@ -70,8 +70,9 @@ namespace aidaTT
 
     /** add a trajectoryElement with a measurement/hit to the trajectory - identified by:
      *  a position, the precision, the surface and a user defined id/pointer
+     *  if this measurement has been successfully added, return true, otherwise return false.
      */
-    void addMeasurement(const Vector3D& position, const std::vector<double>& precision, 
+    bool addMeasurement(const Vector3D& position, const std::vector<double>& precision,
 			const ISurface& surface, void* id, bool isScatterer=false ) ;
     
     

--- a/core/src/trajectory.cc
+++ b/core/src/trajectory.cc
@@ -141,7 +141,7 @@ namespace aidaTT {
 
 
 
-  void trajectory::addMeasurement(const Vector3D& position, const std::vector<double>& precision, 
+  bool trajectory::addMeasurement(const Vector3D& position, const std::vector<double>& precision,
 				  const ISurface& surface, void* id, bool isScatterer)
   {
     
@@ -166,7 +166,7 @@ namespace aidaTT {
 		<< "  does not intersect with surface : " <<  surface
 		<< "  hit will be ignored ! " << std::endl ;
       
-      return ;
+      return false;
     }
     
     //    std::cout << " prevS : " << prevS << " - s to next intersection: " << s << std::endl ;
@@ -235,6 +235,8 @@ namespace aidaTT {
 
     // note: need to get the curvilinear system at s==0. as this is where the local track state is defined
     _initialTrajectoryElements.push_back(new trajectoryElement(s, trkParam, surface, measDir, new_prec, residuals, calculateLocalCurvilinearSystem(0., *trkParam), id , isScatterer ));
+
+    return true;
   }
 
   void trajectory::addScatterer( const ISurface& surface ){


### PR DESCRIPTION



BEGINRELEASENOTES
-  Update trajectory::addMeasurement from void to bool for adding successfully.
    - the success information could be used by "MarlinTrk/src/MarlinAidaTTTrack.cc".
    - Both DDKalTest and AidaTT(GBL) may be used by  "RefitProcessor" and "FullLDCTracking_MarlinTrk" for track fitting.

ENDRELEASENOTES