### PR TITLE
Performance optimisations

### DIFF
--- a/util/include/intersections.hh
+++ b/util/include/intersections.hh
@@ -95,10 +95,9 @@ namespace aidaTT
     class intersections
     {
         public:
-            intersections()
-            {
-                _points.clear();
-            };
+            intersections() {}
+            intersections(double x1, double y1):_points{std::make_pair(x1, y1)} {}
+            intersections(double x1, double y1,double x2, double y2):_points{std::make_pair(x1, y1), std::make_pair(x2, y2)} {}
             unsigned int number() const
             {
                 return _points.size();
@@ -112,7 +111,7 @@ namespace aidaTT
                 return _points.at(i);
             }
         private:
-            std::vector<std::pair<double, double> > _points;
+            std::vector<std::pair<double, double> > _points{};
     };
 
     intersections intersectCircleCircle(const circle&, const circle&);

--- a/util/src/helixUtils.cc
+++ b/util/src/helixUtils.cc
@@ -534,7 +534,7 @@ namespace aidaTT
     const double ny = surf->normal().y();
 
     // calculate distance from origin
-    const double dist = fabs(surf->distance(Vector3D()));
+    const double dist = fabs(surf->origin()*surf->normal());
 
     // define straight line from this
     straightLine line(nx, ny, dist);

--- a/util/src/helixUtils.cc
+++ b/util/src/helixUtils.cc
@@ -90,7 +90,7 @@ namespace aidaTT
     else 
       if( dphi >  M_PI ) dphi -= 2.*M_PI ;
 
-    return ( dphi != 0. ?  ( dx * cosPhi0  + dy * sinPhi0 ) / (sin(dphi) / dphi)  : 0  ) ;
+    return ( dphi != 0. ?  ( dx * cosPhi0  + dy * sinPhi0 ) * dphi / sin(dphi)  : 0  ) ;
   }
 
 

--- a/util/src/helixUtils.cc
+++ b/util/src/helixUtils.cc
@@ -544,7 +544,7 @@ namespace aidaTT
     const double ycenter = calculateYCenter( hp, rp );
     circle circ(xcenter, ycenter, radius);
 
-    intersections candidates = intersectCircleStraightLine(circ, line);
+    intersections const& candidates = intersectCircleStraightLine(circ, line);
 
     if(candidates.number() < 1)
       return false;

--- a/util/src/intersections.cc
+++ b/util/src/intersections.cc
@@ -66,19 +66,17 @@ namespace aidaTT
         const double d = sL.distance();
         const double DISC = sqrt(discriminant);
 
-        const double x1 = x0  + (nx * d + ny * DISC) / sL.normalSquare();
-        const double y1 = y0  + (ny * d - nx * DISC) / sL.normalSquare();
+        const double normSquareInv = 1.0 / sL.normalSquare();
 
-        intersections retType;
-        retType.add(x1, y1);
+        const double x1 = x0  + (nx * d + ny * DISC) * normSquareInv;
+        const double y1 = y0  + (ny * d - nx * DISC) * normSquareInv;
 
         /// return only a single solution, if both are very close
         if(fabs(discriminant) <= 1e-9)
-            return retType;
-        const double x2 = x0  + (nx * d - ny * DISC) / sL.normalSquare();
-        const double y2 = y0  + (ny * d + nx * DISC) / sL.normalSquare();
-        retType.add(x2, y2);
-        return retType;
+          return intersections(x1, y1);
+        const double x2 = x0  + (nx * d - ny * DISC) * normSquareInv;
+        const double y2 = y0  + (ny * d + nx * DISC) * normSquareInv;
+        return intersections(x1, y1, x2, y2);
     }
 
 


### PR DESCRIPTION
Running Z->UDS sample in CLIC Detector no significant changes in the reconstructed tracks, except the track parameters errors change in the last digit.
e.g.:
```
480c480
<  errors:   +5.132359e-03 | -2.099785e-05, +1.122613e-07 | -2.453261e-08, +1.115386e-10, +2.402474e-13 | +2.830744e-04, -1.436741e-06, -4.184194e-10, +3.926882e-01 | +2.395653e-07, -1.408824e-09, -6.237775e-12, -8.192144e-04, +1.860208e-06 |
---
>  errors:   +5.132359e-03 | -2.099785e-05, +1.122613e-07 | -2.453261e-08, +1.115386e-10, +2.402474e-13 | +2.830744e-04, -1.436741e-06, -4.184195e-10, +3.926882e-01 | +2.395653e-07, -1.408824e-09, -6.237775e-12, -8.192144e-04, +1.860208e-06 |
------------------------------------------------------------------------------------------------------------------------------------------------^
```

BEGINRELEASENOTES
- Performance optimisation from running profiler (Intel VTune Amplifier)
ENDRELEASENOTES