### PR TITLE
fix default init of ref to abstract (osx-llvm)

### DIFF
--- a/geometry/include/DD4hepGeometry.hh
+++ b/geometry/include/DD4hepGeometry.hh
@@ -27,7 +27,7 @@ namespace aidaTT
     
 
   private:
-    const dd4hep::Detector& _thedetector{} ;
+    const dd4hep::Detector& _thedetector ;
 
     std::vector<const ISurface* > _surfaceList{};
   };


### PR DESCRIPTION

BEGINRELEASENOTES
- fix default initialization of reference to abstract (osx-llvm)

ENDRELEASENOTES