### PR TITLE
Adopt for cleaning of DD4hep

### DIFF
--- a/core/include/Vector3D.hh
+++ b/core/include/Vector3D.hh
@@ -1,9 +1,9 @@
 #ifdef AIDATT_USE_DD4HEP // only use when not the DD4hep version is available
-#include "DDSurfaces/Vector3D.h"
+#include "DDRec/Vector3D.h"
 
 namespace aidaTT
 {
-  typedef DDSurfaces::Vector3D Vector3D;
+  typedef dd4hep::rec::Vector3D Vector3D;
 }
 #else
 #ifndef VECTOR3D_HH


### PR DESCRIPTION
needed for AIDASoft/DD4hep#345
BEGINRELEASENOTES
- Fix for the removal of DDSurfaces which have been merged into DDRec 
  -  includes from `DDSurfaces` -> `DDRec`
  - namespace `DDSurfaces` -> `dd4hep::rec`

ENDRELEASENOTES