### PR TITLE
Update the minimum cmake to v3.5 to be able to compile with v4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # #require a certain version
-CMAKE_MINIMUM_REQUIRED( VERSION 2.8.2 )
+CMAKE_MINIMUM_REQUIRED( VERSION 3.5 )
 
 # declare the project name
 PROJECT(aidaTT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # #require a certain version
-CMAKE_MINIMUM_REQUIRED( VERSION 3.5 )
+CMAKE_MINIMUM_REQUIRED( VERSION 3.10 )
 
 # declare the project name
 PROJECT(aidaTT)


### PR DESCRIPTION
BEGINRELEASENOTES
- Update the minimum cmake to v3.5 to be able to compile with v4, and then to 3.10 since 3.5 is already deprecated.

ENDRELEASENOTES