### PR TITLE
Install cmake files to lib/cmake/${PROJECT_NAME}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,5 +132,5 @@ install(TARGETS ${PROJECT_NAME}
 
 # generate and install following configuration files
 CONFIGURE_FILE( ${PROJECT_SOURCE_DIR}/cmake/aidaTTConfig.cmake.in aidaTTConfig.cmake @ONLY )
-INSTALL( FILES ${PROJECT_BINARY_DIR}/aidaTTConfig.cmake DESTINATION . )
+INSTALL( FILES ${PROJECT_BINARY_DIR}/aidaTTConfig.cmake DESTINATION lib/cmake/${PROJECT_NAME} )
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Install cmake files to lib/cmake/${PROJECT_NAME}. Similar to what was done in iLCSoft/iLCUtil#36 and iLCSoft/iLCUtil#41. This is needed to make this package work with views in LCGCMake.

ENDRELEASENOTES